### PR TITLE
Chore: optimize enum parsing

### DIFF
--- a/Runtime/Scripts/Schema/Accessor.cs
+++ b/Runtime/Scripts/Schema/Accessor.cs
@@ -159,23 +159,55 @@ namespace GLTFast.Schema
         [NonSerialized]
         GltfAccessorAttributeType m_TypeEnum = GltfAccessorAttributeType.Undefined;
 
+        private readonly Dictionary<string, GltfAccessorAttributeType> accessorAttributesTable =
+            new()
+            {
+                {"SCALAR", GltfAccessorAttributeType.SCALAR},
+                {"Scalar", GltfAccessorAttributeType.SCALAR},
+                {"scalar", GltfAccessorAttributeType.SCALAR},
+                
+                {"VEC2", GltfAccessorAttributeType.VEC2},
+                {"Vec2", GltfAccessorAttributeType.VEC2},
+                {"vec2", GltfAccessorAttributeType.VEC2},
+                
+                {"VEC3", GltfAccessorAttributeType.VEC3},
+                {"Vec3", GltfAccessorAttributeType.VEC3},
+                {"vec3", GltfAccessorAttributeType.VEC3},
+
+                {"VEC4", GltfAccessorAttributeType.VEC4},
+                {"Vec4", GltfAccessorAttributeType.VEC4},
+                {"vec4", GltfAccessorAttributeType.VEC4},
+                
+                {"MAT2", GltfAccessorAttributeType.MAT2},
+                {"Mat2", GltfAccessorAttributeType.MAT2},
+                {"mat2", GltfAccessorAttributeType.MAT2},
+                
+                {"MAT3", GltfAccessorAttributeType.MAT3},
+                {"Mat3", GltfAccessorAttributeType.MAT3},
+                {"mat3", GltfAccessorAttributeType.MAT3},
+
+                {"MAT4", GltfAccessorAttributeType.MAT4},
+                {"Mat4", GltfAccessorAttributeType.MAT4},
+                {"mat4", GltfAccessorAttributeType.MAT4},
+            };
+
         /// <summary>
         /// <see cref="GltfAccessorAttributeType"/> typed/cached getter from the <see cref="type"/> string.
         /// </summary>
         /// <returns>The Accessor's attribute type, if it could be retrieved correctly. <see cref="GltfAccessorAttributeType.Undefined"/> otherwise</returns>
         public GltfAccessorAttributeType GetAttributeType()
         {
-            if (m_TypeEnum != GltfAccessorAttributeType.Undefined)
-                return m_TypeEnum;
-
-            if (!string.IsNullOrEmpty(type))
+            if (m_TypeEnum != GltfAccessorAttributeType.Undefined) return m_TypeEnum;
+            if (string.IsNullOrEmpty(type)) return GltfAccessorAttributeType.Undefined;
+            
+            if (!accessorAttributesTable.TryGetValue(type, out m_TypeEnum))
             {
                 m_TypeEnum = (GltfAccessorAttributeType)Enum.Parse(typeof(GltfAccessorAttributeType), type, true);
-                type = null;
-                return m_TypeEnum;
+                accessorAttributesTable.Add(type, m_TypeEnum);
             }
-
-            return GltfAccessorAttributeType.Undefined;
+            
+            type = null;
+            return m_TypeEnum;
         }
 
         /// <summary>

--- a/Runtime/Scripts/Schema/Accessor.cs
+++ b/Runtime/Scripts/Schema/Accessor.cs
@@ -20,6 +20,7 @@ using UnityEngine.Assertions;
 
 // GLTF_EXPORT
 using UnityEngine.Rendering;
+using System.Collections.Generic;
 
 namespace GLTFast.Schema
 {

--- a/Runtime/Scripts/Schema/GltfAnimation.cs
+++ b/Runtime/Scripts/Schema/GltfAnimation.cs
@@ -16,6 +16,7 @@
 #if UNITY_ANIMATION
 
 using System;
+using System.Collections.Generic;
 
 namespace GLTFast.Schema {
     [Serializable]

--- a/Runtime/Scripts/Schema/GltfCamera.cs
+++ b/Runtime/Scripts/Schema/GltfCamera.cs
@@ -15,6 +15,7 @@
 
 using System;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace GLTFast.Schema
 {

--- a/Runtime/Scripts/Schema/GltfCamera.cs
+++ b/Runtime/Scripts/Schema/GltfCamera.cs
@@ -46,6 +46,16 @@ namespace GLTFast.Schema
 
         Type? m_TypeEnum;
 
+        private readonly Dictionary<string, Type?> cameraTypesTable = new()
+        {
+            {"ORTHOGRAPHIC", Type.Orthographic},
+            {"Orthographic", Type.Orthographic},
+            {"orthographic", Type.Orthographic},
+            {"PERSPECTIVE", Type.Perspective},
+            {"Perspective", Type.Perspective},
+            {"perspective", Type.Perspective},
+        };
+        
         /// <summary>
         /// <see cref="Type"/> typed and cached getter onto <see cref="type"/> string.
         /// </summary>
@@ -56,14 +66,18 @@ namespace GLTFast.Schema
             {
                 return m_TypeEnum.Value;
             }
-
+            
             if (!string.IsNullOrEmpty(type))
             {
-                m_TypeEnum = (Type)Enum.Parse(typeof(Type), type, true);
+                if (!cameraTypesTable.TryGetValue(type, out m_TypeEnum))
+                {
+                    m_TypeEnum = (Type)Enum.Parse(typeof(Type), type, true);
+                    cameraTypesTable.Add(type, m_TypeEnum);
+                }
                 type = null;
                 return m_TypeEnum.Value;
             }
-
+            
             if (orthographic != null) m_TypeEnum = Type.Orthographic;
             if (perspective != null) m_TypeEnum = Type.Perspective;
             return m_TypeEnum ?? Type.Perspective;

--- a/Runtime/Scripts/Schema/LightsPunctual.cs
+++ b/Runtime/Scripts/Schema/LightsPunctual.cs
@@ -16,6 +16,7 @@
 using System;
 using Unity.Mathematics;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace GLTFast.Schema
 {

--- a/Runtime/Scripts/Schema/LightsPunctual.cs
+++ b/Runtime/Scripts/Schema/LightsPunctual.cs
@@ -123,6 +123,19 @@ namespace GLTFast.Schema
         [NonSerialized]
         Type m_TypeEnum = Type.Unknown;
 
+        private readonly Dictionary<string, Type> lightTypesTable = new()
+        {
+            { "SPOT", Type.Spot },
+            { "Spot", Type.Spot },
+            { "spot", Type.Spot },
+            { "DIRECTIONAL", Type.Directional },
+            { "Directional", Type.Directional },
+            { "directional", Type.Directional },
+            { "POINT", Type.Point },
+            { "Point", Type.Point },
+            { "point", Type.Point },
+        };
+        
         /// <summary>
         /// Returns the type of the light
         /// It converts the <see cref="type"/> string and caches it.
@@ -134,14 +147,18 @@ namespace GLTFast.Schema
             {
                 return m_TypeEnum;
             }
-
+            
             if (!string.IsNullOrEmpty(type))
             {
-                m_TypeEnum = (Type)Enum.Parse(typeof(Type), type, true);
+                if (!lightTypesTable.TryGetValue(type, out m_TypeEnum))
+                {
+                    m_TypeEnum = (Type)Enum.Parse(typeof(Type), type, true);
+                    lightTypesTable.Add(type, m_TypeEnum);
+                }
+                
                 type = null;
                 return m_TypeEnum;
             }
-
             return Type.Unknown;
         }
 

--- a/Runtime/Scripts/Schema/Material.cs
+++ b/Runtime/Scripts/Schema/Material.cs
@@ -131,6 +131,19 @@ namespace GLTFast.Schema
 
         AlphaMode? m_AlphaModeEnum;
 
+        private readonly Dictionary<string, AlphaMode?> alphaModesTable = new()
+        {
+            {"OPAQUE", AlphaMode.Opaque},
+            {"Opaque", AlphaMode.Opaque},
+            {"opaque", AlphaMode.Opaque},
+            {"MASK", AlphaMode.Mask},
+            {"Mask", AlphaMode.Mask},
+            {"mask", AlphaMode.Mask},
+            {"BLEND", AlphaMode.Blend},
+            {"Blend", AlphaMode.Blend},
+            {"blend", AlphaMode.Blend},
+        };
+        
         /// <summary>
         /// <see cref="AlphaMode"/> typed and cached getter for <see cref="alphaMode"/> string.
         /// </summary>
@@ -138,17 +151,19 @@ namespace GLTFast.Schema
         public AlphaMode GetAlphaMode()
         {
             if (m_AlphaModeEnum.HasValue)
-            {
                 return m_AlphaModeEnum.Value;
-            }
-
+            
             if (!string.IsNullOrEmpty(alphaMode))
             {
-                m_AlphaModeEnum = (AlphaMode)System.Enum.Parse(typeof(AlphaMode), alphaMode, true);
+                if (!alphaModesTable.TryGetValue(alphaMode, out m_AlphaModeEnum))
+                {
+                    m_AlphaModeEnum = (AlphaMode)Enum.Parse(typeof(AlphaMode), alphaMode, true);
+                    alphaModesTable.Add(alphaMode, m_AlphaModeEnum);
+                }
                 alphaMode = null;
                 return m_AlphaModeEnum.Value;
             }
-
+            
             return AlphaMode.Opaque;
         }
 

--- a/Runtime/Scripts/Schema/Material.cs
+++ b/Runtime/Scripts/Schema/Material.cs
@@ -15,6 +15,7 @@
 
 using Unity.Mathematics;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace GLTFast.Schema
 {

--- a/Runtime/Scripts/Schema/Material.cs
+++ b/Runtime/Scripts/Schema/Material.cs
@@ -15,6 +15,7 @@
 
 using Unity.Mathematics;
 using UnityEngine;
+using System;
 using System.Collections.Generic;
 
 namespace GLTFast.Schema


### PR DESCRIPTION
Closes https://app.zenhub.com/workspaces/workstream-core-tech-63aaac346e1c8d00104586e8/issues/gh/decentraland/unity-renderer/5276
After this, loading assets will not have almost any Enum.Parse involved.

Profiling from running GenesisPlaza, where left is the old approach and right is the one from the current PR
![image](https://github.com/decentraland/glTFast/assets/35366872/59c7d4b9-f109-46be-a8b6-4d94d2390654)
